### PR TITLE
Add type-safety checks around Thingpedia-defined functions

### DIFF
--- a/lib/modules/base_generic.js
+++ b/lib/modules/base_generic.js
@@ -101,6 +101,6 @@ module.exports = class BaseGenericModule {
     }
 
     getDeviceFactory() {
-        return this._loaded;
+        return Promise.resolve(this._loaded);
     }
 };

--- a/lib/modules/base_js.js
+++ b/lib/modules/base_js.js
@@ -108,7 +108,11 @@ module.exports = class BaseJavascriptModule {
         deviceClass.require = function(subpath) {
             return require(path.resolve(modulePath, subpath));
         };
-        this._completeLoading(deviceClass);
+        try {
+            this._completeLoading(deviceClass);
+        } catch(e) {
+            return Promise.reject(e);
+        }
 
         const subdevices = deviceClass.subdevices || {};
         return Promise.all((this.manifest.child_types || []).map((childId) => {

--- a/lib/modules/errors.js
+++ b/lib/modules/errors.js
@@ -1,0 +1,18 @@
+// -*- mode: js; indent-tabs-mode: nil; js-basic-offset: 4 -*-
+//
+// This file is part of ThingEngine
+//
+// Copyright 2018 Google LLC
+//
+// Author: Giovanni Campagna <gcampagn@cs.stanford.edu>
+//
+// See LICENSE for details
+"use strict";
+
+class ImplementationError extends Error {
+    constructor(msg) {
+        super(`Implementation Error: ${msg}`);
+    }
+}
+
+module.exports = { ImplementationError };

--- a/lib/modules/v2.js
+++ b/lib/modules/v2.js
@@ -9,9 +9,50 @@
 // See LICENSE for details
 "use strict";
 
+const stream = require('stream');
 const Tp = require('thingpedia');
 
 const BaseJavascriptModule = require('./base_js');
+const { ImplementationError } = require('./errors');
+
+function isIterable(result) {
+    return typeof result === 'object' && result !== null &&
+        typeof result[Symbol.iterator] === 'function';
+}
+
+// wrap implementation functions in async functions
+// the goal is two fold:
+// - the calling code can expect a promise, rather than a raw JS result
+// - synchronous errors (eg JS errors TypeErrors) get converted
+//   into rejected promise, even if the error occurs before the
+//   callee has a chance to set up Promise.resolve().then(() => ...)
+// - type checking of the return value ensures understandable
+//   error messages, rather than failing deep in a compiled ThingTalk
+//   function with no stack
+function safeWrapQuery(query, queryName) {
+    return async function () {
+        const result = await query.apply(this, arguments);
+        if (!isIterable(result))
+            throw new ImplementationError(`The query ${queryName} must return an iterable object (eg. Array), got ${result}`);
+        return result;
+    };
+}
+function safeWrapAction(action) {
+    return async function () {
+        return action.apply(this, arguments);
+    };
+}
+
+// same thing, but for subscribe_, which must *synchronously*
+// return a stream
+function safeWrapSubscribe(subscribe, queryName) {
+    return function () {
+        const result = subscribe.apply(this, arguments);
+        if (!(result instanceof stream.Readable))
+            throw new ImplementationError(`The subscribe function for ${queryName} must return an instance of stream.Readable, got ${result}`);
+        return result;
+    };
+}
 
 module.exports = class ThingpediaModuleV2 extends BaseJavascriptModule {
     static get [Symbol.species]() {
@@ -21,20 +62,31 @@ module.exports = class ThingpediaModuleV2 extends BaseJavascriptModule {
     _completeLoading(module) {
         super._completeLoading(module);
 
+        for (let action in this.manifest.actions) {
+            if (typeof module.prototype['do_' + action] !== 'function')
+                throw new ImplementationError(`Implementation for action ${action} missing`);
+            module.prototype['do_' + action] = safeWrapAction(module.prototype['do_' + action]);
+        }
         for (let query in this.manifest.queries) {
+            const pollInterval = this.manifest.queries[query].poll_interval;
+            if (pollInterval === 0 && typeof module.prototype['subscribe_' + query] !== 'function')
+                throw new ImplementationError(`Poll interval === 0 but no subscribe function was found`);
+            if (typeof module.prototype['get_' + query] !== 'function')
+                throw new ImplementationError(`Implementation for query ${query} missing`);
+
+            module.prototype['get_' + query] = safeWrapQuery(module.prototype['get_' + query], query);
             if (!module.prototype['subscribe_' + query]) {
-                const pollInterval = this.manifest.queries[query].poll_interval;
                 if (pollInterval > 0) {
                     module.prototype['subscribe_' + query] = function(params, state, filter) {
                         return new Tp.Helpers.PollingStream(state, pollInterval, () => this['get_' + query](params));
                     };
-                } else if (pollInterval === 0) {
-                    throw new Error('Misconfiguration: poll interval === 0 but no subscribe function was found');
-                } else {
+                } else if (pollInterval < 0) {
                     module.prototype['subscribe_' + query] = function(params, state, filter) {
                         throw new Error('This query is non-deterministic and cannot be monitored');
                     };
                 }
+            } else {
+                module.prototype['subscribe_' + query] = safeWrapSubscribe(module.prototype['subscribe_' + query], query);
             }
             if (!module.prototype['history_' + query]) {
                 module.prototype['history_' + query] = function(params, base, delta, filters) {

--- a/test/device-classes/org.thingpedia.test.broken.manifest.json
+++ b/test/device-classes/org.thingpedia.test.broken.manifest.json
@@ -1,0 +1,63 @@
+{
+    "kind": "org.thingpedia.test.broken",
+    "module_type": "org.thingpedia.v2",
+    "version": 1,
+
+    "auth": {
+        "type": "none"
+    },
+
+    "queries": {
+        "something": {
+            "args": [{
+                "name": "v1",
+                "type": "String"
+            }, {
+                "name": "v2",
+                "type": "Number"
+            }],
+            "poll_interval": 0
+        },
+        "something_poll1": {
+            "args": [{
+                "name": "v1",
+                "type": "String"
+            }, {
+                "name": "v2",
+                "type": "Number"
+            }],
+            "poll_interval": 1000
+        },
+        "something_poll2": {
+            "args": [{
+                "name": "v1",
+                "type": "String"
+            }, {
+                "name": "v2",
+                "type": "Number"
+            }],
+            "poll_interval": 1000
+        },
+        "something_poll3": {
+            "args": [{
+                "name": "v1",
+                "type": "String"
+            }, {
+                "name": "v2",
+                "type": "Number"
+            }],
+            "poll_interval": 1000
+        },
+        "something_poll4": {
+            "args": [{
+                "name": "v1",
+                "type": "String"
+            }, {
+                "name": "v2",
+                "type": "Number"
+            }],
+            "poll_interval": 1000
+        }
+    },
+    "actions": {}
+}

--- a/test/device-classes/org.thingpedia.test.broken.noaction.manifest.json
+++ b/test/device-classes/org.thingpedia.test.broken.noaction.manifest.json
@@ -1,0 +1,20 @@
+{
+    "kind": "org.thingpedia.test.broken.noaction",
+    "module_type": "org.thingpedia.v2",
+    "version": 1,
+
+    "auth": {
+        "type": "none"
+    },
+
+    "queries": {
+    },
+    "actions": {
+        "something_else": {
+            "args": [{
+                "name": "v3",
+                "type": "String"
+            }]
+        }
+    }
+}

--- a/test/device-classes/org.thingpedia.test.broken.noaction/index.js
+++ b/test/device-classes/org.thingpedia.test.broken.noaction/index.js
@@ -1,0 +1,19 @@
+// -*- mode: js; indent-tabs-mode: nil; js-basic-offset: 4 -*-
+//
+// This file is part of ThingEngine
+//
+// Copyright 2018 The Board of Trustees of the Leland Stanford Junior University
+//
+// Author: Giovanni Campagna <gcampagn@cs.stanford.edu>
+//
+// See LICENSE for details
+"use strict";
+
+const Tp = require('thingpedia');
+
+module.exports = class MyDevice extends Tp.BaseDevice {
+    constructor(engine, state) {
+        super(engine, state);
+        this.uniqueId = 'org.thingpedia.test.broken.noaction';
+    }
+};

--- a/test/device-classes/org.thingpedia.test.broken.noaction/package.json
+++ b/test/device-classes/org.thingpedia.test.broken.noaction/package.json
@@ -1,0 +1,4 @@
+{"name":"org.thingpedia.test.broken.noaction",
+ "main": "index.js",
+ "thingpedia-version":1
+}

--- a/test/device-classes/org.thingpedia.test.broken.noquery.manifest.json
+++ b/test/device-classes/org.thingpedia.test.broken.noquery.manifest.json
@@ -1,0 +1,23 @@
+{
+    "kind": "org.thingpedia.test.broken.noquery",
+    "module_type": "org.thingpedia.v2",
+    "version": 1,
+
+    "auth": {
+        "type": "none"
+    },
+
+    "queries": {
+        "something": {
+            "args": [{
+                "name": "v1",
+                "type": "String"
+            }, {
+                "name": "v2",
+                "type": "Number"
+            }],
+            "poll_interval": 1000
+        }
+    },
+    "actions": {}
+}

--- a/test/device-classes/org.thingpedia.test.broken.noquery/index.js
+++ b/test/device-classes/org.thingpedia.test.broken.noquery/index.js
@@ -1,0 +1,19 @@
+// -*- mode: js; indent-tabs-mode: nil; js-basic-offset: 4 -*-
+//
+// This file is part of ThingEngine
+//
+// Copyright 2018 The Board of Trustees of the Leland Stanford Junior University
+//
+// Author: Giovanni Campagna <gcampagn@cs.stanford.edu>
+//
+// See LICENSE for details
+"use strict";
+
+const Tp = require('thingpedia');
+
+module.exports = class MyDevice extends Tp.BaseDevice {
+    constructor(engine, state) {
+        super(engine, state);
+        this.uniqueId = 'org.thingpedia.test.broken.noquery';
+    }
+};

--- a/test/device-classes/org.thingpedia.test.broken.noquery/package.json
+++ b/test/device-classes/org.thingpedia.test.broken.noquery/package.json
@@ -1,0 +1,4 @@
+{"name":"org.thingpedia.test.broken.noquery",
+ "main": "index.js",
+ "thingpedia-version":1
+}

--- a/test/device-classes/org.thingpedia.test.broken.nosubscribe.manifest.json
+++ b/test/device-classes/org.thingpedia.test.broken.nosubscribe.manifest.json
@@ -1,0 +1,23 @@
+{
+    "kind": "org.thingpedia.test.broken.nosubscribe",
+    "module_type": "org.thingpedia.v2",
+    "version": 1,
+
+    "auth": {
+        "type": "none"
+    },
+
+    "queries": {
+        "something": {
+            "args": [{
+                "name": "v1",
+                "type": "String"
+            }, {
+                "name": "v2",
+                "type": "Number"
+            }],
+            "poll_interval": 0
+        }
+    },
+    "actions": {}
+}

--- a/test/device-classes/org.thingpedia.test.broken.nosubscribe/index.js
+++ b/test/device-classes/org.thingpedia.test.broken.nosubscribe/index.js
@@ -1,0 +1,23 @@
+// -*- mode: js; indent-tabs-mode: nil; js-basic-offset: 4 -*-
+//
+// This file is part of ThingEngine
+//
+// Copyright 2018 The Board of Trustees of the Leland Stanford Junior University
+//
+// Author: Giovanni Campagna <gcampagn@cs.stanford.edu>
+//
+// See LICENSE for details
+"use strict";
+
+const Tp = require('thingpedia');
+
+module.exports = class MyDevice extends Tp.BaseDevice {
+    constructor(engine, state) {
+        super(engine, state);
+        this.uniqueId = 'org.thingpedia.test.broken.nosubscribe';
+    }
+
+    get_something() {
+        return [{v1: 'foo', v2: 42}];
+    }
+};

--- a/test/device-classes/org.thingpedia.test.broken.nosubscribe/package.json
+++ b/test/device-classes/org.thingpedia.test.broken.nosubscribe/package.json
@@ -1,0 +1,4 @@
+{"name":"org.thingpedia.test.broken.nosubscribe",
+ "main": "index.js",
+ "thingpedia-version":1
+}

--- a/test/device-classes/org.thingpedia.test.broken/index.js
+++ b/test/device-classes/org.thingpedia.test.broken/index.js
@@ -1,0 +1,39 @@
+// -*- mode: js; indent-tabs-mode: nil; js-basic-offset: 4 -*-
+//
+// This file is part of ThingEngine
+//
+// Copyright 2018 The Board of Trustees of the Leland Stanford Junior University
+//
+// Author: Giovanni Campagna <gcampagn@cs.stanford.edu>
+//
+// See LICENSE for details
+"use strict";
+
+const Tp = require('thingpedia');
+
+module.exports = class MyDevice extends Tp.BaseDevice {
+    constructor(engine, state) {
+        super(engine, state);
+        this.uniqueId = 'org.thingpedia.test.broken';
+    }
+
+    get_something() {
+        return [{v1: 'foo', v2: 42}];
+    }
+    subscribe_something() {
+        return null;
+    }
+
+    get_something_poll1() {
+        return null;
+    }
+    get_something_poll2() {
+        return undefined;
+    }
+    get_something_poll3() {
+        return {};
+    }
+    get_something_poll4() {
+        return 'foo';
+    }
+};

--- a/test/device-classes/org.thingpedia.test.broken/package.json
+++ b/test/device-classes/org.thingpedia.test.broken/package.json
@@ -1,0 +1,4 @@
+{"name":"org.thingpedia.test.broken",
+ "main": "index.js",
+ "thingpedia-version":1
+}

--- a/test/device-classes/org.thingpedia.test.mydevice/index.js
+++ b/test/device-classes/org.thingpedia.test.mydevice/index.js
@@ -36,6 +36,9 @@ module.exports = class MyDevice extends Tp.BaseDevice {
     get_something_poll() {
         return [{v1: 'foo', v2: 42}];
     }
+    get_something_nomonitor() {
+        return [{v1: 'foo', v2: 42}];
+    }
     do_something_else({ v3 }) {
         assert.strictEqual(v3, 'bar');
     }

--- a/test/mock.js
+++ b/test/mock.js
@@ -90,6 +90,10 @@ const mockClient = {
         case 'org.thingpedia.test.mydevice':
         case 'org.thingpedia.test.collection':
         case 'org.thingpedia.test.subdevice':
+        case 'org.thingpedia.test.broken':
+        case 'org.thingpedia.test.broken.noquery':
+        case 'org.thingpedia.test.broken.noaction':
+        case 'org.thingpedia.test.broken.nosubscribe':
         case 'com.xkcd':
         case 'org.httpbin':
         case 'org.httpbin.oauth':


### PR DESCRIPTION
Developers make mistakes, and developers don't necessarily have the
source code of Almond or the patience to debug stack traces deep
in thingengine-core (or worse, in compiled ThingTalk code).

Catch common mistakes early and fail with an understandable stack
trace.