### PR TITLE
Make use of package_version class annotation

### DIFF
--- a/lib/downloader.js
+++ b/lib/downloader.js
@@ -191,6 +191,11 @@ module.exports = class ModuleDownloader {
         // a manifest and back
 
         const manifest = classDef.toManifest();
+        if (classDef.annotations.package_version)
+            manifest.package_version = classDef.annotations.package_version.toJS();
+        else
+            manifest.package_version = manifest.version;
+
         //console.log(manifest);
         return manifest;
     }

--- a/lib/modules/base_js.js
+++ b/lib/modules/base_js.js
@@ -74,6 +74,9 @@ module.exports = class BaseJavascriptModule {
     get version() {
         return this._manifest.version;
     }
+    get package_version() {
+        return this._manifest.package_version;
+    }
 
     clearCache() {
         this._loading = null;
@@ -100,8 +103,8 @@ module.exports = class BaseJavascriptModule {
     _loadJsModule(id) {
         var modulePath = this._modulePath;
         var version = JSON.parse(fs.readFileSync(modulePath + '/package.json').toString('utf8'))['thingpedia-version'];
-        if (version !== this._manifest.version) {
-            console.log('Cached module ' + this.id + ' is out of date');
+        if (version !== this._manifest.package_version) {
+            console.log(`Cached module ${this.id} is out of date (found ${version}, want ${this._manifest.package_version})`);
             return null;
         }
 

--- a/test/device-classes/org.thingpedia.test.pkgversion.tt
+++ b/test/device-classes/org.thingpedia.test.pkgversion.tt
@@ -1,0 +1,9 @@
+class @org.thingpedia.test.pkgversion
+#[version=2]
+#[package_version=0] {
+  import loader from @org.thingpedia.v2();
+  import config from @org.thingpedia.config.none();
+
+  query something(out v1: String,
+                  out v2: Number);
+}

--- a/test/device-classes/org.thingpedia.test.pkgversion/index.js
+++ b/test/device-classes/org.thingpedia.test.pkgversion/index.js
@@ -1,0 +1,23 @@
+// -*- mode: js; indent-tabs-mode: nil; js-basic-offset: 4 -*-
+//
+// This file is part of ThingEngine
+//
+// Copyright 2018 The Board of Trustees of the Leland Stanford Junior University
+//
+// Author: Giovanni Campagna <gcampagn@cs.stanford.edu>
+//
+// See LICENSE for details
+"use strict";
+
+const Tp = require('thingpedia');
+
+module.exports = class MyDevice extends Tp.BaseDevice {
+    constructor(engine, state) {
+        super(engine, state);
+        this.uniqueId = 'org.thingpedia.test.pkgversion';
+    }
+
+    get_something() {
+        return [{v1: 'foo', v2: 42}];
+    }
+};

--- a/test/device-classes/org.thingpedia.test.pkgversion/package.json
+++ b/test/device-classes/org.thingpedia.test.pkgversion/package.json
@@ -1,0 +1,4 @@
+{"name":"org.thingpedia.test.pkgversion",
+ "main": "index.js",
+ "thingpedia-version":0
+}

--- a/test/mock.js
+++ b/test/mock.js
@@ -93,6 +93,7 @@ class MockClient extends BaseClient {
     async getDeviceCode(kind) {
         switch (kind) {
         case 'org.thingpedia.test.mydevice':
+        case 'org.thingpedia.test.pkgversion':
         case 'org.thingpedia.test.collection':
         case 'org.thingpedia.test.subdevice':
         case 'org.thingpedia.test.broken':
@@ -154,7 +155,13 @@ class State {
 }
 
 function toManifest(classCode) {
-    return ThingTalk.Ast.toManifest(ThingTalk.Grammar.parse(classCode));
+    const classDef = ThingTalk.Grammar.parse(classCode).classes[0];
+    const manifest = classDef.toManifest();
+    if (classDef.annotations.package_version)
+        manifest.package_version = classDef.annotations.package_version.toJS();
+    else
+        manifest.package_version = manifest.version;
+    return manifest;
 }
 
 module.exports = { toManifest, mockPlatform, mockClient, mockEngine, State };

--- a/test/test_api.js
+++ b/test/test_api.js
@@ -42,7 +42,8 @@ async function testQuery() {
         { name: 'org.thingpedia.test.broken.nosubscribe', version: 1 },
         { name: 'org.thingpedia.test.collection', version: 1 },
         { name: 'org.thingpedia.test.mydevice', version: 1 },
-        { name: 'org.thingpedia.test.subdevice', version: 1 }
+        { name: 'org.thingpedia.test.pkgversion', version: 2 },
+        { name: 'org.thingpedia.test.subdevice', version: 1 },
     ]);
 }
 

--- a/test/test_v2_device.js
+++ b/test/test_v2_device.js
@@ -215,12 +215,24 @@ async function testThingpedia() {
     assert.strictEqual(typeof factory.prototype.subscribe_random_comic, 'function');
 }
 
+async function testPkgVersion() {
+    const downloader = new ModuleDownloader(mockPlatform, mockClient);
+    const module = await downloader.getModule('org.thingpedia.test.pkgversion');
+
+    assert.strictEqual(module.id, 'org.thingpedia.test.pkgversion');
+    assert.strictEqual(module.version, 2);
+    assert.strictEqual(module.package_version, 0);
+
+    await module.getDeviceFactory();
+}
+
 async function main() {
     await testPreloaded();
     await testSubdevice();
     await testBrokenDevices();
     await testThingpedia();
     await testDownloader();
+    await testPkgVersion();
 }
 module.exports = main;
 if (!module.parent)


### PR DESCRIPTION
In the future, we will want to decouple the version of the JS
code (which is written in thingpedia-version in package.json)
to the version of the device class, so that we can update
metadata and thingtalk code without storing a new version of the
JS code (which is expensive).

The first step in that direction is to support a #[package_version]
annotation of the class. If the annotation is not present, it
defaults to the #[version] annotation instead.